### PR TITLE
数组和指针的索引计算

### DIFF
--- a/include/AST/Type/Array.h
+++ b/include/AST/Type/Array.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <numeric>
 #include <memory>
+#include <span>
 
 #include "TypeBase.h"
 
@@ -77,6 +78,16 @@ namespace SysYust::AST {
          */
         [[nodiscard]] std::size_t getExtent(std::size_t) const;
 
+        /**
+         * @brief 解引用 layer 层后的类型
+         */
+        [[nodiscard]] const Type& index(std::size_t layer) const;
+
+        /**
+         * @brief 使用给定索引后产生的偏移量,外层数组的索引位于前
+         */
+        [[nodiscard]] std::size_t offsetWith(const std::span<std::size_t> &ind) const;
+
         [[nodiscard]] bool match(const SysYust::AST::Array &) const override;
         [[nodiscard]] bool match(const SysYust::AST::Pointer &) const override;
 
@@ -91,7 +102,7 @@ namespace SysYust::AST {
             }
         }
 
-        std::string toString() const noexcept override;
+        [[nodiscard]] std::string toString() const noexcept override;
 
     private:
         const Type &_baseType; ///< 数组的元素类型

--- a/include/AST/Type/Pointer.h
+++ b/include/AST/Type/Pointer.h
@@ -4,6 +4,8 @@
 #define SYSYUST_AST_POINTER_H
 
 #include <set>
+#include <span>
+
 #include "TypeBase.h"
 #include "Array.h"
 
@@ -37,8 +39,21 @@ namespace SysYust::AST {
 
         /**
          * @brief 获取指向的类型
+         * @todo 重构为 baseType
          */
         [[nodiscard]] const Type& getBase() const;
+
+        /**
+         * @brief 解引用 layer 层后的类型
+         */
+        [[nodiscard]] const Type& index(std::size_t layer) const;
+
+        /**
+         * @brief 使用给定索引后产生的偏移量,外层数组的索引位于前
+         */
+        [[nodiscard]] std::size_t offsetWith(const std::span<std::size_t>& ind) const;
+
+
 
         [[nodiscard]] bool match(const SysYust::AST::Pointer &) const override;
         [[nodiscard]] bool match(const SysYust::AST::Array &) const override;

--- a/test/ArrayIndexTest.cpp
+++ b/test/ArrayIndexTest.cpp
@@ -1,0 +1,64 @@
+//
+// Created by LL06p on 24-7-9.
+//
+
+#include <gtest/gtest.h>
+
+#include "AST/Type.h"
+
+using namespace SysYust::AST;
+
+TEST(ArrayIndexTest, ArrayPlainTest) {
+    auto &a1 = Array::create(Int_v, {10});
+    EXPECT_EQ(&a1.index(0), &a1);
+    EXPECT_EQ(&a1.index(1), &Int_v);
+
+    std::vector<std::size_t> offset{5};
+    EXPECT_EQ(a1.offsetWith(offset), 5);
+    offset[0] = 0;
+    EXPECT_EQ(a1.offsetWith(offset), 0);
+}
+
+TEST(ArrayIndexTest, ArrayTest) {
+    // 相当于声明 int a1[4][20][10]
+    auto &a1 = Array::create(Int_v, {10, 20, 4});
+
+    auto &a2 = Array::create(Int_v, {10, 20});
+    auto &a3 = Array::create(Int_v, {10});
+    EXPECT_EQ(&a1.index(1), &a2) << a1.index(1).toString() << ":" << a2.toString();
+    EXPECT_EQ(&a1.index(2), &a3) << a1.index(2).toString() << ":" << a3.toString();
+    EXPECT_EQ(&a1.index(3), &Int_v);
+
+    std::vector<std::size_t> offset1{1, 2, 3};
+    std::vector<std::size_t> offset2{1, 2};
+    std::vector<std::size_t> offset3{1};
+    EXPECT_EQ(a1.offsetWith(offset1), 223);
+    EXPECT_EQ(a1.offsetWith(offset2), 220);
+    EXPECT_EQ(a1.offsetWith(offset3), 200);
+}
+
+TEST(ArrayIndexTest, PointerTest) {
+    auto &p1 = Pointer::create(Int_v);
+    EXPECT_EQ(&p1.index(0), &p1);
+    EXPECT_EQ(&p1.index(1), &Int_v);
+
+    std::vector<std::size_t> offset{0};
+    EXPECT_EQ(p1.offsetWith(offset), 0);
+    offset = {15};
+    EXPECT_EQ(p1.offsetWith(offset), 15);
+
+    auto &a1 = Array::create(Int_v, {10, 20, 10});
+    auto &p2 = Pointer::create(a1);
+    auto &a2 = Array::create(Int_v, {10, 20});
+    auto &a3 = Array::create(Int_v, {10});
+    EXPECT_EQ(&p2.index(0), &p2);
+    EXPECT_EQ(&p2.index(1), &a1);
+    EXPECT_EQ(&p2.index(2), &a2);
+    EXPECT_EQ(&p2.index(4), &Int_v);
+    offset = {1};
+    EXPECT_EQ(p2.offsetWith(offset), 2000);
+    offset = {1, 2};
+    EXPECT_EQ(p2.offsetWith(offset), 2000+2*200);
+    offset = {1, 2, 3};
+    EXPECT_EQ(p2.offsetWith(offset), 2000+2*200+3*10);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,9 @@ target_link_libraries(NodeTest GTest::gtest_main AST)
 AddGTestFromFile(TypeToStringTest)
 target_link_libraries(TypeToStringTest PUBLIC AST)
 
+AddGTestFromFile(ArrayIndexTest)
+target_link_libraries(ArrayIndexTest PUBLIC AST)
+
 gtest_discover_tests(BuildSystemTest)
 gtest_discover_tests(LoggerTest)
 gtest_discover_tests(TypeMatchTest)


### PR DESCRIPTION
为数组和指针添加索引计算

- index 计算若干曾索引后的类型
- offsetWith 计算以给定索引后距离首个单元移动的单元数（Int 和 Float 都是4字节一个单元）

P.S. Array 的 数组维度存储是按照声明顺序的反序存储的，但是解引用的顺序是按照正序设计的。