### PR TITLE
添加一个简单的Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM cg/compile-x86:rust2ndclang12
+LABEL authors="LL06p"
+
+RUN apt update
+RUN apt install cmake gdb -y
+
+ENTRYPOINT ["bash"]


### PR DESCRIPTION
可以基于 cg/compile-x86 镜像构建一个带有CMake的开发环境

```bash
docker build -t online-env-dev .
```